### PR TITLE
New Tests for Nav, Widgets

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -1,14 +1,18 @@
-import { Ng2SimpleAppPage } from './app.po';
+import { AngularTestingExamplesPage } from './app.po';
 
 describe('ng2-simple-app App', function() {
-  let page: Ng2SimpleAppPage;
+  let page: AngularTestingExamplesPage;
 
   beforeEach(() => {
-    page = new Ng2SimpleAppPage();
+    page = new AngularTestingExamplesPage();
   });
 
-  it('should display message saying app works', () => {
+  it('should display message saying Angular 2 REST Website', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toEqual('app works!');
+
+    page.getLayoutTitleText()
+      .then((txt) => {
+        expect(txt).toEqual('Angular 2 REST Website');
+      });
   });
 });

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -1,11 +1,28 @@
 import { browser, element, by } from 'protractor';
 
-export class Ng2SimpleAppPage {
-  navigateTo() {
-    return browser.get('/');
+export class AngularTestingExamplesPage {
+  navigateTo(link?: string) {
+    if(link === undefined) {
+      return browser.get('/');
+    } else {
+      return browser.get(link);
+    }
   }
 
-  getParagraphText() {
-    return element(by.css('app-root h1')).getText();
+  getLayoutTitleText() {
+    return element(by.css('.mdl-layout-title')).getText();
+  };
+
+  getNavLinks() {
+    return element.all(by.css('.mdl-navigation__link'));
+  }
+
+  getCreateCardTitle() {
+    let form = element(by.tagName('form'));
+    return form.element(by.css('.mdl-card__title-text'));
+  }
+
+  getCardTitles() {
+    return element.all(by.css('.mdl-card__title-text'));
   }
 }

--- a/e2e/nav.e2e-spec.ts
+++ b/e2e/nav.e2e-spec.ts
@@ -1,0 +1,37 @@
+import { AngularTestingExamplesPage } from './app.po';
+
+describe('Navigation', function() {
+  let page: AngularTestingExamplesPage;
+
+  beforeEach(() => {
+    page = new AngularTestingExamplesPage();
+  });
+
+  it('should navigate to the Widgets page from the Items page and back', () => {
+    page.navigateTo();
+
+    // EXPECTING THE CREATE FORM TITLE TO CONTAIN 'Item'
+    expect(page.getCreateCardTitle().getText()).toContain('Item');
+
+    page.navigateTo('/widgets');
+
+    let navLinks = [];
+
+    page.getNavLinks()
+      .then((links) => {
+        navLinks = links;
+        // EXPECTING 2 LINKS AT THE TOP RIGHT
+        expect(links.length).toEqual(2);
+        return navLinks[1].click();
+      })
+      .then(() => {
+        // EXPECTING THE CREATE FORM TITLE TO CONTAIN 'Widget'
+        expect(page.getCreateCardTitle().getText()).toContain('Widget');
+        return navLinks[0].click();
+      })
+      .then(() => {
+        // EXPECTING THE CREATE FORM TITLE TO CONTAIN 'Item'
+        expect(page.getCreateCardTitle().getText()).toContain('Item');
+      });
+  });
+});

--- a/e2e/widgets.e2e-spec.ts
+++ b/e2e/widgets.e2e-spec.ts
@@ -1,0 +1,148 @@
+import { AngularTestingExamplesPage } from './app.po';
+import { WidgetsPage } from './widgets.po';
+
+describe('Widgets', () => {
+  let page:AngularTestingExamplesPage;
+  let widgetPage: WidgetsPage;
+  let widgetsCount = 0;
+
+  beforeEach(() => {
+    page = new AngularTestingExamplesPage();
+    widgetPage = new WidgetsPage();
+
+    page.navigateTo('/widgets');
+
+  });
+
+  it('should have widgets', () => {
+    widgetPage.getWidgetsCount()
+      .then((count) => {
+         widgetsCount = count;
+         // EXPECT THE DEFAULT DATABASE TO HAVE 3 WIDGETS
+         expect(widgetsCount).toEqual(3);
+      });
+
+  });
+
+  it('should have a title, description for each widget', () => {
+    widgetPage.getWidgetsCount()
+      .then((count) => {
+         widgetsCount = count;
+         // EXPECT THE DEFAULT DATABASE TO HAVE 3 WIDGETS
+         expect(widgetsCount).toEqual(3);
+
+         for (let i = 0; i < widgetsCount; i++) {
+           const widget = widgetPage.getWidget(i);
+           // EXPECT EACH WIDGET TO HAVE A TITLE AND DESCRIPTION ELEMENT
+           expect(widgetPage.getWidgetTitleElement(widget)).toBeDefined();
+           expect(widgetPage.getWidgetDescriptionElement(widget)).toBeDefined();
+         }
+      });
+
+  });
+
+  it('should clear form on cancel', () => {
+    let startingCount: number;
+    let cancel;
+    const titleText = 'E2E Widget 0';
+    const descText = 'This is Widget 0 for E2E testing.';
+
+    widgetPage.getWidgetsCount()
+      .then((count) => {
+        startingCount = count;
+        widgetsCount = count;
+        cancel = widgetPage.getFormCancelButton();
+
+        // EXPECT THE CANCEL BUTTON TO BE DISABLED
+        expect(cancel).toBeTruthy();
+
+        widgetPage.getFormNameInput().sendKeys(titleText);
+        widgetPage.getFormDescriptionInput().sendKeys(descText);
+
+        return cancel.click();
+      })
+      .then(() => {
+        return widgetPage.getWidgetsCount();
+      })
+      .then((count) => {
+        widgetsCount = count;
+        expect(widgetsCount).toEqual(startingCount);
+
+        // EXPECT THE FORM TO BE EMPTY
+        widgetPage.getFormNameInput().getText()
+          .then((txt) => {
+            expect(txt).toEqual('');
+          });
+        widgetPage.getFormDescriptionInput().getText()
+          .then((txt) => {
+            expect(txt).toEqual('');
+          });
+      });
+
+  });
+
+  it('should create a widget', () => {
+    let startingCount: number;
+    let submit;
+    const titleText = 'E2E Widget 0';
+    const descText = 'This is Widget 0 for E2E testing.';
+
+    widgetPage.getWidgetsCount()
+      .then((count) => {
+        startingCount = count;
+        widgetsCount = count;
+        submit = widgetPage.getFormSubmitButton();
+
+        // EXPECT THE SUBMIT BUTTON TO BE DISABLED
+        expect(submit.isEnabled()).toBeFalsy();
+        widgetPage.getFormNameInput().sendKeys(titleText);
+
+        // EXPECT THE SUBMIT BUTTON TO NOT BE DISABLED
+        expect(submit.isEnabled()).toBeTruthy();
+        widgetPage.getFormDescriptionInput().sendKeys(descText);
+
+        return submit.click();
+      })
+      .then(() => {
+        return widgetPage.getWidgetsCount();
+      })
+      .then((count) => {
+        widgetsCount = count;
+        expect(widgetsCount).toBeGreaterThan(startingCount);
+        expect(widgetsCount - 1).toEqual(startingCount);
+
+        // EXPECT THE SUBMIT BUTTON TO BE DISABLED
+        expect(submit.isEnabled()).toBeFalsy();
+
+        // EXPECT THE WIDGET TEXT TO BE WHAT WAS SET
+        const widgets = widgetPage.getWidgets();
+        const newWidget = widgets.get(widgetsCount - 1);
+        expect(widgetPage.getWidgetTitleElement(newWidget).getText()).toEqual(titleText);
+        expect(widgetPage.getWidgetDescriptionElement(newWidget).getText()).toEqual(descText);
+      });
+
+  });
+
+  it('should delete a widget', () => {
+    let startingCount: number;
+    widgetPage.getWidgetsCount()
+      .then((count) => {
+        startingCount = count;
+        widgetsCount = count;
+
+        const widgets = widgetPage.getWidgets();
+        const close = widgetPage.getWidgetCloseButton(widgets.get(widgetsCount - 1));
+
+        return close.click();
+      })
+      .then(() => {
+        return widgetPage.getWidgetsCount();
+      })
+      .then((count) => {
+        widgetsCount = count;
+        expect(widgetsCount).toBeLessThan(startingCount);
+        expect(widgetsCount + 1).toEqual(startingCount);
+      });
+  });
+
+});

--- a/e2e/widgets.po.ts
+++ b/e2e/widgets.po.ts
@@ -1,0 +1,52 @@
+import { browser, element, by } from 'protractor';
+
+export class WidgetsPage {
+
+  getWidgetsList() {
+    return element.all(by.css('.mdl-cell')).get(0);
+  }
+
+  getWidgets() {
+    return this.getWidgetsList().all(by.css('.item-card'))
+  }
+
+  getWidget(num: number) {
+    return this.getWidgetsList().all(by.css('.item-card')).get(num);
+  }
+
+  getWidgetTitleElement(widget) {
+    return widget.element(by.css('.mdl-card__title'));
+  }
+
+  getWidgetDescriptionElement(widget) {
+    return widget.element(by.css('.mdl-card__supporting-text'));
+  }
+
+  getWidgetCloseButton(widget) {
+    return widget.element(by.tagName('button'));
+  }
+
+  getWidgetsCount() {
+    return element.all(by.css('.mdl-cell')).get(0).all(by.css('.item-card')).count()
+      .then((len) => {
+        return len;
+      });
+  }
+
+  // FORM METHODS
+  getFormNameInput() {
+    return element(by.tagName('form')).element(by.name('name'));
+  }
+
+  getFormDescriptionInput() {
+    return element(by.tagName('form')).element(by.name('description'));
+  }
+
+  getFormCancelButton() {
+    return element(by.tagName('form')).all(by.tagName('button')).get(0);
+  }
+
+  getFormSubmitButton() {
+    return element(by.tagName('form')).all(by.tagName('button')).get(1);
+  }
+}


### PR DESCRIPTION
This PR should be merged after previous PR [https://github.com/onehungrymind/angular-testing-examples/pull/2](https://github.com/onehungrymind/angular-testing-examples/pull/2)

This PR represents:
- Updates to `app.po.ts`: 
     - Changed class name to match app
     - Added some methods for getting elements
- Update of `app.e2e-spec.ts` to use `ap.po.ts` new class name
- Creation of `nav.e2e-spec.ts` to test navigation
- Creation of `widgets.e2e.ts` and `widgets.po.ts` to test widgets
